### PR TITLE
[Hotfix] Se corrige problema en IOS11 con statusbar y barra gris (parte superior e inferior)

### DIFF
--- a/src/ios/webview/WebViewPlugin.h
+++ b/src/ios/webview/WebViewPlugin.h
@@ -38,6 +38,7 @@ under the License.
 - (void)show:(CDVInvokedUrlCommand*)command;
 - (void)hide:(CDVInvokedUrlCommand*)command;
 - (void)exitApp:(CDVInvokedUrlCommand*)command;
+- (void)webViewAdjustmenBehavior:(CDVInvokedUrlCommand*)command;
 - (void)webViewFinished;
 
 @end

--- a/src/ios/webview/WebViewPlugin.m
+++ b/src/ios/webview/WebViewPlugin.m
@@ -9,13 +9,12 @@
 
 @synthesize webViewController;
 
-- (void)pluginInitialize
-{
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
+- (void)webViewAdjustmenBehavior:(CDVInvokedUrlCommand*)command{
+  #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
     if (@available(iOS 11.0, *)) {
         [self.webView.scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
     }
-#endif
+  #endif
 }
 
 - (void)subscribeCallback:(CDVInvokedUrlCommand*)command

--- a/src/ios/webview/WebViewPlugin.m
+++ b/src/ios/webview/WebViewPlugin.m
@@ -9,6 +9,15 @@
 
 @synthesize webViewController;
 
+- (void)pluginInitialize
+{
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
+    if (@available(iOS 11.0, *)) {
+        [self.webView.scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+    }
+#endif
+}
+
 - (void)subscribeCallback:(CDVInvokedUrlCommand*)command
 {
     [self.commandDelegate runInBackground:^{

--- a/www/webViewPlugin.js
+++ b/www/webViewPlugin.js
@@ -32,6 +32,9 @@ module.exports = (function() {
     cordova.exec(function(){},function(){}, 'WebViewPlugin', 'exitApp', []);
   };
 
+  var _setWebViewBehavior = function() {
+    cordova.exec(function(){},function(){}, 'WebViewPlugin', 'webViewAdjustmenBehavior', []);
+  };
 
   return {
     Show: _show,
@@ -40,7 +43,8 @@ module.exports = (function() {
     SubscribeCallback: _subscribeCallback,
     SubscribeExitCallback: _subscribeExitCallback,
     ExitApp: _exitApp,
-    HideLoading: _hideLoading
+    HideLoading: _hideLoading,
+    SetWebViewBehavior: _setWebViewBehavior
   };
 
 })();


### PR DESCRIPTION
Se agrega método para deshabilitar statusbar en ios11.

Esta medida es provisoria mientras cordova no saque una actualización ni se haga un cambio a dicha acctualización.

