### PR TITLE
Fix: Android url prefixing

### DIFF
--- a/src/android/cl/kunder/webview/WebViewActivity.java
+++ b/src/android/cl/kunder/webview/WebViewActivity.java
@@ -35,7 +35,7 @@ public class WebViewActivity extends CordovaActivity {
             showLoading();
         }
         
-        loadUrl((url.matches("^(.://|javascript:)[\\s\\S]$") ? "" : "file:///android_asset/www/" + (isPluginCryptFileActive() ? "+++/" : "")) + url);
+        loadUrl((url.matches("^(.*://|javascript:)[\\s\\S]*$") ? "" : "file:///android_asset/www/" + (isPluginCryptFileActive() ? "+++/" : "")) + url);
     }
 
     public static boolean showLoading() {


### PR DESCRIPTION
Fixes issue #43 

During the 2.6->2.7 transition, the url-prefixing regex in `WebViewActivity.java` was refactored: two globbing operators (`*`) were removed, causing much more aggressive prefixing. This seems unintentional: [the commit - d8a3edf](https://github.com/kunder-lab/cl.kunder.webview/commit/d8a3edf8a3ed6937bf35e98fa264d8eb106dfc6e) introduced additional prefixing for the encrypted-file feature.

---
### URL examples
`https://remote.com/cordova.html` - previously no prefixing, **now prefixed to `file:///android_asset/www/https://remote.com/cordova.html`**

`javascript:alert(1)` - previously no prefixing, **now prefixed to `file:///android_asset/www/javascript:alert(1)`**

---

This PR restores the regex to it's `v2.6.0` functionality.
